### PR TITLE
Recognize hidden LambdaForms as intrinsification roots

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/phases/InlineBeforeAnalysisPolicyUtils.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/phases/InlineBeforeAnalysisPolicyUtils.java
@@ -179,7 +179,17 @@ public class InlineBeforeAnalysisPolicyUtils {
     private final Set<ResolvedJavaMethod> explicitMethodHandleIntrinisificationRoots = GuestAccess.elements().abstractMemorySegmentGetSetMethods;
 
     public boolean isMethodHandleIntrinsificationRoot(ResolvedJavaMethod method) {
+        /*
+         * Hidden/generated LambdaForm classes may not expose their class file bytes through normal
+         * class loader resources. When running with a Java-side JVMCI fallback for raw annotation
+         * bytes, @LambdaForm.Compiled can therefore be unavailable even though HotSpot marks these
+         * methods as compiled LambdaForms. Treat the generated hidden LambdaForm holders as
+         * intrinsification roots as well.
+         */
+        String declaringClassName = method.getDeclaringClass().getName();
+        boolean hiddenCompiledLambdaForm = declaringClassName.startsWith("Ljava/lang/invoke/LambdaForm$MH") || declaringClassName.startsWith("Ljava/lang/invoke/LambdaForm$DMH");
         return AnnotationUtil.isAnnotationPresent(method, COMPILED_LAMBDA_FORM_ANNOTATION) ||
+                        hiddenCompiledLambdaForm ||
                         explicitMethodHandleIntrinisificationRoots.contains(OriginalMethodProvider.getOriginalMethod(method));
     }
 


### PR DESCRIPTION
When native-image runs with a Java-side JVMCI fallback for raw annotation bytes, hidden/generated LambdaForm classes do not expose their class bytes as normal class loader resources. As a result, `@java.lang.invoke.LambdaForm.Compiled` can be unavailable for hidden classes such as:

- `java.lang.invoke.LambdaForm$MH/...`
- `java.lang.invoke.LambdaForm$DMH/...`

Those methods are still HotSpot compiled LambdaForms and need to be treated as method-handle intrinsification roots. Otherwise the generated image can leave runtime MethodHandle resolution paths in place and fail with recursive `MethodHandleNatives.resolve` / `Class.getDeclaredConstructor` stack overflows.

This patch preserves the existing annotation-based detection and adds a targeted fallback for hidden LambdaForm holder names.

Validation note: I attempted a focused `mx build --dependencies=com.oracle.svm.hosted`, but this checkout retains the normal guard rejecting a GraalVM base JDK. The same fallback was tested in the downstream local native-image experiment with the JVMCI annotation fallback, where it fixed the runtime StackOverflowError for a hello-world image.